### PR TITLE
Add Runtime Dependencies to tunnelvr.service

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,17 +37,34 @@
       "inputs": {
         "godot": "godot",
         "nixpkgs": "nixpkgs",
+        "survex": "survex",
         "tunnelvr": "tunnelvr"
+      }
+    },
+    "survex": {
+      "locked": {
+        "lastModified": 1623256563,
+        "narHash": "sha256-XQd6VULbUsBksOF9hOZGBZzvzborDv1TvtmFmEsPrwc=",
+        "owner": "matthewcroughan",
+        "repo": "nixpkgs",
+        "rev": "9007ca34b8c4a02ba145eea102cb2c343de97aae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "matthewcroughan",
+        "ref": "add-survex",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "tunnelvr": {
       "flake": false,
       "locked": {
-        "lastModified": 1623055339,
-        "narHash": "sha256-Z59d79lLjxQZyKsr3nOfxhX7Ab1Rx34IOcL7VxSa8KU=",
+        "lastModified": 1623075182,
+        "narHash": "sha256-u7uUU/co7YmWUeJkzrxs6UXkkr9THbx6EU3Mq1TcLLE=",
         "owner": "goatchurchprime",
         "repo": "tunnelvr",
-        "rev": "1dd1ea79792e9d9dd48257669808845625393063",
+        "rev": "445fc835f45055c531b7b0980c1bd31de1932d9c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    survex.url = "github:matthewcroughan/nixpkgs/add-survex";
     godot = {
       url = "github:godotengine/godot/3.3.2-stable";
       flake = false;
@@ -14,7 +15,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, godot, tunnelvr }: {
+  outputs = { self, nixpkgs, godot, tunnelvr, survex }: {
 
 #    packages.x86_64-linux = let pkgs = import nixpkgs { system = "x86_64-linux"; }; in {
 #      tunnelvr = pkgs.callPackage ./nix/runcommand-tunnelvr.nix {};
@@ -37,6 +38,8 @@
         src = godot;
         patches = [];
       });
+
+      survex = survex.legacyPackages.x86_64-linux.survex;
 
       tunnelvr = 
       runCommandNoCC "tunnelvr" {

--- a/nix-cheatsheet.md
+++ b/nix-cheatsheet.md
@@ -1,0 +1,59 @@
+This repository is a **Flake**. A Flake is something that will be consumed by
+another system, in our case a server on Hetzner. Thus, we have the concept of
+them/us (like git branches), or of a producer/consumer.
+
+This tunnelvr repository has a `flake.nix` at its root, it provides a
+`nixosModule` named `tunnelvr` which has a systemd service. In this context, it
+is the producer, which will be consumed by the Hetzner server.
+
+Our Hetzner server will only do what this tunnelvr repository's `flake.nix`
+tells it to. Nothing more nothing less.
+
+# Cheatsheet
+
+### Follow the log of tunnelvr on the Hetzner server
+
+```
+journalctl -fu tunnelvr
+```
+
+### Updating the `flake.lock`
+
+#### TunnelVR (Producer)
+
+1. In `flake.nix`, modify the `inputs.tunnelvr.url` to refer to the new tag you
+   want to be available to all consumers of this flake.
+
+    ###### Before:
+    ```nix
+    {
+      inputs = {
+        tunnelvr = {
+          url = "github:goatchurchprime/tunnelvr/v0.5.1";
+          flake = false;
+        };
+      };
+    }
+    ```
+    ###### After:
+    ```nix
+    {
+      inputs = {
+        tunnelvr = {
+          url = "github:goatchurchprime/tunnelvr/v0.6.2";
+          flake = false;
+        };
+      };
+    }
+    ```
+
+2. Run `nix flake lock --update-input tunnelvr`
+
+#### Hetzner (Consumer)
+
+This will update tunnelvr from the perspective of the server and make any
+changes to the [flake.nix](flake.nix) of this repo true. For example, if you
+have changed the version or source of Godot by modifying `inputs.godot.url`, it
+will recompile Godot and use it for running the TunnelVR pck file.
+
+1. `nixos-rebuild switch --update-input tunnelvr`

--- a/nix/tunnelvr-service.nix
+++ b/nix/tunnelvr-service.nix
@@ -20,6 +20,7 @@ in
   config = mkIf cfg.enable {
     systemd.services.tunnelvr = {
       description = "TunnelVR Service";
+      path = [ pkgs.python3Minimal pkgs.survex ];
       wantedBy = [ "multi-user.target" ];
       after = [ "networking.target" ];
       serviceConfig = {


### PR DESCRIPTION
Adds:
- [`python3Minimal`](https://github.com/NixOS/nixpkgs/blob/nixos-21.05/pkgs/development/interpreters/python/cpython/default.nix#L437)
- [`survex`](https://github.com/MatthewCroughan/nixpkgs/commit/05ed13f835e0b0f2c3117179791b08dd759b7ec7)

to the tunnelvr systemd service which is generated by `nix/tunnelvr.service.nix` by filling in the `path` attribute of [`systemd.services.<name>.path`](https://search.nixos.org/options?channel=21.05&show=systemd.services.%3Cname%3E.path&from=0&size=50&sort=relevance&query=systemd.services.%3Cname%3E.path)

Also adds a cheat sheet for the benefit of @goatchurchprime 